### PR TITLE
Update makefile to 1.2.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ src/ontology/patterns
 src/ontology/seed.txt
 src/ontology/target/
 src/patterns/imports/seed_sorted.txt
+src/ontology/Dockerfile
+src/ontology/patterns.sh

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -1,7 +1,7 @@
 # ----------------------------------------
 # Makefile for hp
 # Generated using ontology-starter-kit
-# ODK Version: v1.2.18
+# ODK Version: v1.2.19
 # ----------------------------------------
 # <do not edit above this line>
 
@@ -26,7 +26,7 @@ REPORT_FAIL_ON =            none
 OBO_FORMAT_OPTIONS =        
 SPARQL_VALIDATION_CHECKS =  equivalent-classes trailing-whitespace owldef-self-reference xref-syntax nolabels
 SPARQL_EXPORTS =            basic-report class-count-by-prefix edges xrefs obsoletes synonyms
-ODK_VERSION =               v1.2.18
+ODK_VERSION =               v1.2.19
 
 TODAY ?= $(shell date +%Y-%m-%d)
 OBODATE ?= $(shell date +'%d:%m:%Y %H:%M')
@@ -48,7 +48,7 @@ RELEASE_ARTEFACTS = $(sort  base simple-non-classified full base full)
 .PHONY: .FORCE
 all: odkversion all_imports patterns all_main all_subsets sparql_test all_reports all_assets
 test: odkversion sparql_test all_reports
-	$(ROBOT) reason --input $(SRC) --reasoner ELK  --equivalent-classes-allowed asserted-only --output test.owl && rm test.owl && echo "Success"
+	$(ROBOT) reason --input $(SRC) --reasoner ELK  --equivalent-classes-allowed asserted-only --exclude-tautologies structural --output test.owl && rm test.owl && echo "Success"
 
 odkversion:
 	echo "ODK Makefile version: $(ODK_VERSION) (this is the version of the ODK with which this Makefile was generated, not the version of the ODK you are running)" &&\
@@ -218,7 +218,7 @@ $(ONT)-base.owl: $(SRC) $(OTHER_SRC)
 # Full: The full artefacts with imports merged, reasoned
 $(ONT)-full.owl: $(SRC) $(OTHER_SRC)
 	$(ROBOT) merge --input $< \
-		reason --reasoner ELK --equivalent-classes-allowed asserted-only \
+		reason --reasoner ELK --equivalent-classes-allowed asserted-only --exclude-tautologies structural \
 		relax \
 		reduce -r ELK \
 		annotate --ontology-iri $(ONTBASE)/$@ --version-iri $(ONTBASE)/releases/$(TODAY)/$@ --output $@.tmp.owl && mv $@.tmp.owl $@
@@ -270,6 +270,8 @@ imports/%_import.obo: imports/%_import.owl
 	@if [ $(IMP) = true ]; then $(ROBOT) convert --check false -i $< -f obo -o $@.tmp.obo && mv $@.tmp.obo $@; fi
 imports/%_import.json: imports/%_import.owl
 	@if [ $(IMP) = true ]; then $(ROBOT) convert --check false -i $< -f json -o $@.tmp.json && mv $@.tmp.json $@; fi
+
+
 # ----------------------------------------
 # Mirroring upstream ontologies
 # ----------------------------------------
@@ -277,8 +279,7 @@ imports/%_import.json: imports/%_import.owl
 
 IMP=true # Global parameter to bypass import generation
 MIR=true # Global parameter to bypass mirror generation
-
-
+PAT=true # Global parameter to bypass pattern generation
 
 ## ONTOLOGY: nbo
 ## Copy of nbo is re-downloaded whenever source changes
@@ -335,7 +336,7 @@ mirror/ro.owl: mirror/ro.trigger
 mirror/chebi.trigger: $(SRC)
 
 mirror/chebi.owl: mirror/chebi.trigger
-	@if [ $(MIR) = true ] && [ $(IMP) = true ]; then $(ROBOT) convert -I $(URIBASE)/chebi.owl -o $@.tmp.owl && mv $@.tmp.owl $@; fi
+	@if [ $(MIR) = true ] && [ $(IMP) = true ]; then $(ROBOT) convert -I http://purl.obolibrary.org/obo/chebi.owl.gz -o $@.tmp.owl && mv $@.tmp.owl $@; fi
 
 .PRECIOUS: mirror/%.owl
 
@@ -414,7 +415,7 @@ sparql_test: $(SRC)
 # ROBOT report
 # ----------------------------------------
 reports/%-obo-report.tsv: %
-	$(ROBOT) report -i $< --fail-on $(REPORT_FAIL_ON) -o $@
+	$(ROBOT) report -i $< --fail-on $(REPORT_FAIL_ON) --print 5 -o $@
 
 # ----------------------------------------
 # Sparql queries: Exports
@@ -448,16 +449,18 @@ patterns: all_imports $(PATTERNDIR)/pattern.owl $(PATTERNDIR)/definitions.owl
 pattern_clean:
 	echo "Not implemented"
 
-pattern_schema_checks: $(PATTERNDIR)/dosdp-patterns
-	simple_pattern_tester.py $(PATTERNDIR)/dosdp-patterns/ # 2>&1 | tee $@
+pattern_schema_checks: update_patterns
+	@if [ $(PAT) = true ]; then $(PATTERN_TESTER) $(PATTERNDIR)/dosdp-patterns/; fi
 
 #This command is a workaround for the absence of -N and -i in wget of alpine (the one ODK depend on now). It downloads all patterns specified in external.txt
-$(PATTERNDIR)/dosdp-patterns: .FORCE
-	cat $(PATTERNDIR)/dosdp-patterns/external.txt | sed 's!.*/!!' | sed 's! !!g' |  xargs -I{} rm -f $(PATTERNDIR)/dosdp-patterns/{}
-	cat $(PATTERNDIR)/dosdp-patterns/external.txt | sed 's! !!g' | xargs -I{} wget -q {} -P $(PATTERNDIR)/dosdp-patterns
+update_patterns: .FORCE
+	rm -f $(PATTERNDIR)/dosdp-patterns/*.yaml.1
+	wget -i $(PATTERNDIR)/dosdp-patterns/external.txt --backups=1 -P $(PATTERNDIR)/dosdp-patterns
+	rm -f $(PATTERNDIR)/dosdp-patterns/*.yaml.1
 
-$(PATTERNDIR)/pattern.owl: pattern_schema_checks $(PATTERNDIR)/dosdp-patterns
-	$(DOSDPT) prototype --obo-prefixes --template=$(PATTERNDIR)/dosdp-patterns --outfile=$@
+
+$(PATTERNDIR)/pattern.owl: pattern_schema_checks update_patterns
+	@if [ $(PAT) = true ]; then $(DOSDPT) prototype --obo-prefixes --template=$(PATTERNDIR)/dosdp-patterns --outfile=$@; fi
 
 individual_patterns_default := $(patsubst %.tsv, $(PATTERNDIR)/data/default/%.ofn, $(notdir $(wildcard $(PATTERNDIR)/data/default/*.tsv)))
 pattern_term_lists_default := $(patsubst %.tsv, $(PATTERNDIR)/data/default/%.txt, $(notdir $(wildcard $(PATTERNDIR)/data/default/*.tsv)))
@@ -467,26 +470,25 @@ pattern_term_lists_default := $(patsubst %.tsv, $(PATTERNDIR)/data/default/%.txt
 
 
 # Generating the individual pattern modules and merging them into definitions.owl
-$(PATTERNDIR)/definitions.owl: prepare_patterns $(individual_patterns_default)  
-	$(ROBOT) merge $(addprefix -i , $(individual_patterns_default))   annotate --ontology-iri $(ONTBASE)/patterns/definitions.owl  --version-iri $(ONTBASE)/releases/$(TODAY)/patterns/definitions.owl -o definitions.ofn &&\
-	mv definitions.ofn $@
+$(PATTERNDIR)/definitions.owl: prepare_patterns update_patterns $(individual_patterns_default)  
+	@if [ $(PAT) = true ]; then $(ROBOT) merge $(addprefix -i , $(individual_patterns_default))   annotate --ontology-iri $(ONTBASE)/patterns/definitions.owl  --version-iri $(ONTBASE)/releases/$(TODAY)/patterns/definitions.owl -o definitions.ofn && mv definitions.ofn $@; fi
 
 $(PATTERNDIR)/data/default/%.ofn: $(PATTERNDIR)/data/default/%.tsv $(PATTERNDIR)/dosdp-patterns/%.yaml $(SRC) all_imports .FORCE
-	dosdp-tools generate --catalog=catalog-v001.xml --infile=$< --template=$(word 2, $^) --ontology=$(word 3, $^) --obo-prefixes=true --restrict-axioms-to=logical --outfile=$@
+	@if [ $(PAT) = true ]; then $(DOSDPT) generate --catalog=catalog-v001.xml --infile=$< --template=$(word 2, $^) --ontology=$(word 3, $^) --obo-prefixes=true --restrict-axioms-to=logical --outfile=$@; fi
 
 
 
 
 
-# Generating the seed file from all the TSVs
+# Generating the seed file from all the TSVs. If Pattern generation is deactivated, we still extract a seed from definitions.owl
 $(PATTERNDIR)/all_pattern_terms.txt: $(pattern_term_lists_default)   $(PATTERNDIR)/pattern_owl_seed.txt
-	cat $^ | sort | uniq > $@
+	@if [ $(PAT) = true ]; then cat $^ | sort | uniq > $@; else $(ROBOT) query --use-graphs true -f csv -i ../patterns/definitions.owl --query ../sparql/terms.sparql $@; fi
 
 $(PATTERNDIR)/pattern_owl_seed.txt: $(PATTERNDIR)/pattern.owl
-	@if [ $(IMP) = true ]; then $(ROBOT) query --use-graphs true -f csv -i $< --query ../sparql/terms.sparql $@; fi
+	@if [ $(PAT) = true ]; then $(ROBOT) query --use-graphs true -f csv -i $< --query ../sparql/terms.sparql $@; fi
 
 $(PATTERNDIR)/data/default/%.txt: $(PATTERNDIR)/dosdp-patterns/%.yaml $(PATTERNDIR)/data/default/%.tsv .FORCE
-	dosdp-tools terms --infile=$(word 2, $^) --template=$< --obo-prefixes=true --outfile=$@
+	@if [ $(PAT) = true ]; then $(DOSDPT) terms --infile=$(word 2, $^) --template=$< --obo-prefixes=true --outfile=$@; fi
 
 .PHONY: prepare_patterns
 prepare_patterns:
@@ -501,5 +503,8 @@ prepare_patterns:
 
 
 
+
+update_repo:
+	sh ../scripts/update_repo.sh
 
 include hp.Makefile

--- a/src/ontology/hp-odk.yaml
+++ b/src/ontology/hp-odk.yaml
@@ -1,0 +1,36 @@
+id: hp
+title: "Human Phenotype Ontology"
+github_org: obophenotype
+repo: human-phenotype-ontology
+report_fail_on: none
+use_dosdps: TRUE
+dosdp_tools_options: "--obo-prefixes=true --restrict-axioms-to=logical"
+namespaces: 
+  - http://purl.obolibrary.org/obo/HP_
+  - http://purl.obolibrary.org/obo/hp
+release_artefacts: 
+  - base
+  - simple-non-classified
+  - full
+primary_release: simple-non-classified
+export_formats:
+  - owl
+  - obo
+  - json
+import_group:
+  products:
+    - id: nbo
+      mirror_from: http://purl.obolibrary.org/obo/nbo/nbo-base.owl
+    - id: pr
+    - id: go
+    - id: uberon 
+    - id: ro
+    - id: chebi
+      mirror_from: http://purl.obolibrary.org/obo/chebi.owl.gz
+    - id: hsapdv
+    - id: pato
+    - id: cl
+      mirror_from: http://purl.obolibrary.org/obo/cl/cl-base.owl
+    - id: mpath
+robot_java_args: '-Xmx8G'
+allow_equivalents: asserted-only

--- a/src/ontology/tmp/README.md
+++ b/src/ontology/tmp/README.md
@@ -1,0 +1,1 @@
+# This folder contains files that are regenerated with every release to keep the src/ontology folder clean

--- a/src/scripts/update_repo.sh
+++ b/src/scripts/update_repo.sh
@@ -1,0 +1,20 @@
+echo "This (experimental) update script will create a new repo according to your config file. It will:" 
+echo "(1) overwrite your repositories Makefile, ODK sparql queries (your custom queries wont be touched) and docker wrapper (run.sh)."
+echo "(2) and add missing files, if any."
+
+set -e
+
+OID=hp
+SRCDIR=../
+CONFIG=$OID"-odk.yaml"
+
+rm -rf target
+mkdir target
+/tools/odk.py seed -c -g False -C $CONFIG
+ls -l target/$OID/src
+ls -l $SRCDIR
+rsync -r -u --ignore-existing target/$OID/src/ $SRCDIR
+cp target/$OID/src/scripts/update_repo.sh $SRCDIR/scripts/
+cp target/$OID/src/ontology/Makefile $SRCDIR/ontology/
+cp target/$OID/src/ontology/run.sh $SRCDIR/ontology/
+cp -r target/$OID/src/sparql/* $SRCDIR/sparql/


### PR DESCRIPTION
This adds a bunch of new features to the Makfile, for example:

- Pattern generation may now be skipped, using `sh run.sh make PAT=false ...`
- The repo may now be easily updated when the configuration of HP changes (new imports are added etc): `sh run.sh make update_repo`
- pattern generation will be more robust (some bugfixes)
- Tautologies like owl:Nothing subclass owl:Nothing will be removed from release files