### PR TITLE
Moved two EQs from abnormal level in location to abnormal level

### DIFF
--- a/src/patterns/data/default/abnormalLevelOfChemicalEntity.tsv
+++ b/src/patterns/data/default/abnormalLevelOfChemicalEntity.tsv
@@ -1,0 +1,3 @@
+defined_class	defined_class_label	chemical_entity	chemical_entity_label	location	location_label
+HP:0410176	Abnormal glucose-6-phosphate dehydrogenase level	PR:000007749	glucose-6-phosphate 1-dehydrogenase	UBERON:0000178	blood
+HP:0040214	Abnormal insulin level	PR:000009054	insulin	UBERON:0000178	blood

--- a/src/patterns/data/default/abnormalLevelOfChemicalEntityInLocation.tsv
+++ b/src/patterns/data/default/abnormalLevelOfChemicalEntityInLocation.tsv
@@ -71,7 +71,5 @@ HP:0004364	Abnormal circulating nitrogen compound concentration	CHEBI:51143	nitr
 HP:0004361	Abnormality of circulating leptin level	PR:000009758	leptin 	UBERON:0000178	blood
 HP:0003112	Abnormality of serum amino acid level	CHEBI:33709	amino acid	UBERON:0000178	blood
 HP:0003111	Abnormal blood ion concentration	CHEBI:24867	monoatomic ion	UBERON:0000178	blood
-HP:0410176	Abnormal glucose-6-phosphate dehydrogenase level	PR:000007749	glucose-6-phosphate 1-dehydrogenase	UBERON:0000178	blood
-HP:0040214	Abnormal insulin level	PR:000009054	insulin	UBERON:0000178	blood
 HP:0040176	Abnormal circulating phospholipid concentration	CHEBI:16247	phospholipid	UBERON:0000178	blood
 HP:0012146	Abnormality of von Willebrand factor	PR:000017364	von Willebrand factor	UBERON:0000178	blood


### PR DESCRIPTION
This was necessary to account for the HP structure: the inLocation variant already existed, and the no-location variant is supposed to be a grouping for the in location ones.