### PR TITLE
Adding QC check for synonyms ending with illegal char

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -33,7 +33,7 @@ REPORT_FAIL_ON =            ERROR
 REPORT_LABEL =              
 REPORT_PROFILE_OPTS =       
 OBO_FORMAT_OPTIONS =        
-SPARQL_VALIDATION_CHECKS =   equivalent-classes owldef-self-reference
+SPARQL_VALIDATION_CHECKS =   equivalent-classes owldef-self-reference synonym_ends_with_illegal_character
 SPARQL_EXPORTS =             basic-report xrefs synonyms layperson-synonyms
 ODK_VERSION_MAKEFILE =      v1.2.29
 

--- a/src/ontology/hp-odk.yaml
+++ b/src/ontology/hp-odk.yaml
@@ -54,6 +54,7 @@ robot_report:
   custom_sparql_checks :
     - equivalent-classes
     - owldef-self-reference
+    - synonym_ends_with_illegal_character
   custom_sparql_exports :
     - basic-report
     - xrefs

--- a/src/sparql/synonym_ends_with_illegal_character-violation.sparql
+++ b/src/sparql/synonym_ends_with_illegal_character-violation.sparql
@@ -1,0 +1,16 @@
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
+
+SELECT ?x (STR(?lab) AS ?label) ?syn_type WHERE {
+	?x rdf:type owl:Class .
+	?x ?syn_type ?lab . 
+	VALUES ?syn_type { 
+		oboInOwl:hasExactSynonym oboInOwl:hasRelatedSynonym oboInOwl:hasBroadSynonym oboInOwl:hasNarrowSynonym
+	}
+	FILTER(regex(str(?lab), "[. ]$"))
+	FILTER(isIRI(?x) && regex(str(?x), "http://purl.obolibrary.org/obo/HP_"))
+	FILTER NOT EXISTS {?x owl:deprecated ?y}
+}
+ORDER BY ?x


### PR DESCRIPTION
As per discussions on HPO mailing list, this PR introduces a check to ensure that no synonym ends with a period.

- [x] Please make sure https://github.com/obophenotype/human-phenotype-ontology/issues/7014 is closed before merging this!