### PR TITLE
Permanently removing NBO seizures

### DIFF
--- a/src/ontology/hp.Makefile
+++ b/src/ontology/hp.Makefile
@@ -158,6 +158,7 @@ imports/nbo_import.owl: mirror/nbo.owl imports/nbo_terms_combined.txt
 		query --update ../sparql/inject-subset-declaration.ru \
 		query --query ../sparql/classes-without-labels.sparql tmp/classes-without-labels.txt \
 		remove -T tmp/classes-without-labels.txt \
+		remove --term NBO:0000012 --select "self descendants" \
 		annotate --ontology-iri $(ONTBASE)/$@ $(ANNOTATE_ONTOLOGY_VERSION) --output $@.tmp.owl && mv $@.tmp.owl $@; fi
 .PRECIOUS: imports/nbo_import.owl
 

--- a/src/ontology/imports/nbo_import.owl
+++ b/src/ontology/imports/nbo_import.owl
@@ -10,8 +10,8 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
     <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/hp/imports/nbo_import.owl">
-        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/hp/releases/2021-10-10/imports/nbo_import.owl"/>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2021-10-10</owl:versionInfo>
+        <owl:versionIRI rdf:resource="http://purl.obolibrary.org/obo/hp/releases/2021-12-19/imports/nbo_import.owl"/>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2021-12-19</owl:versionInfo>
     </owl:Ontology>
     
 
@@ -299,20 +299,6 @@
     
 
 
-    <!-- http://purl.obolibrary.org/obo/NBO_0000012 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000012">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000243"/>
-        <dc:date>2011-04-14T01:03:39Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0001250</oboInOwl:xref>
-        <oboInOwl:xref>MP:0002064</oboInOwl:xref>
-        <rdfs:label>seizures/epilepsy</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/NBO_0000015 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000015">
@@ -355,21 +341,6 @@
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:xref>GO:0030431</oboInOwl:xref>
         <rdfs:label>sleeping behavior</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000025 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000025">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000012"/>
-        <obo:IAO_0000115>&quot;An uncontrolled, paroxysmal neuronal discharge in any part of the brain; it may cause physical or mental symptoms and may be convulsive or nonconvulsive&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-04-14T01:03:39Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>epileptic seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>unprovoked seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <rdfs:label>seizures</rdfs:label>
     </owl:Class>
     
 
@@ -1761,21 +1732,6 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/NBO_0000642 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000642">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000012"/>
-        <obo:IAO_0000115>&quot;Two or more unprovoked recurrent seizures.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-27T11:42:33Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>unprovoked seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0001275</oboInOwl:xref>
-        <rdfs:label>epilepsy</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/NBO_0000643 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000643">
@@ -1802,71 +1758,6 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
     
 
 
-    <!-- http://purl.obolibrary.org/obo/NBO_0000646 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000646">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000025"/>
-        <obo:IAO_0000115>&quot;A seizure which affect only a part of the brain at onset.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Focal_seizures]</obo:IAO_0000115>
-        <dc:date>2011-05-27T12:49:09Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>focal seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>localized seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0007359</oboInOwl:xref>
-        <rdfs:comment>Partial seizures begin with an electrical discharge in one limited area of the brain.</rdfs:comment>
-        <rdfs:label>partial seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000647 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000647">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000646"/>
-        <obo:IAO_0000115>&quot;A partial seizure which affect only a small region of the brain, often the temporal lobes and/or hippocampi whilst consciousness is unaffected.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Simple_partial_seizure]</obo:IAO_0000115>
-        <dc:date>2011-05-27T12:51:40Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0002349</oboInOwl:xref>
-        <rdfs:comment>Depending on the area of cerebral cortex involved, symptoms may be motor, cognitive, sensory, autonomic, or affective. Consciousness is not impaired.</rdfs:comment>
-        <rdfs:label>simple partial seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000648 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000648">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000646"/>
-        <obo:IAO_0000115>&quot;A seizure that is associated with bilateral cerebral hemisphere involvement and causes impairment of awareness or responsiveness, i.e. loss of consciousness.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Complex_partial_seizures]</obo:IAO_0000115>
-        <dc:date>2011-05-27T12:59:01Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>psychomotor seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>temporal lobe seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0002384</oboInOwl:xref>
-        <oboInOwl:xref>MP:0002195</oboInOwl:xref>
-        <rdfs:label>complex partial seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000651 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000651">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000647"/>
-        <obo:IAO_0000115>&quot;A simple partial seizure affecting the kinesthetic behavior.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-27T02:50:59Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>focal clonic seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>motor seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0002266</oboInOwl:xref>
-        <rdfs:label>simple partial seizure with motor signs</rdfs:label>
-    </owl:Class>
-    
-
-
     <!-- http://purl.obolibrary.org/obo/NBO_0000655 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000655">
@@ -1889,246 +1780,6 @@ owl:qualifier some &apos;temporally extended&apos;)</oboInOwl:note>
         <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
         <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
         <rdfs:label>somatic sensation related behavior phenotype</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000662 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000662">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000025"/>
-        <obo:IAO_0000115>&quot;A seizure which affect the whole of the brain at onset.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-27T03:46:46Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>primarily generalized seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0002197</oboInOwl:xref>
-        <rdfs:comment>Primary generalized seizures begin with a widespread electrical discharge that involves both sides of the brain at once.</rdfs:comment>
-        <rdfs:label>generalized seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000663 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000663">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000646"/>
-        <dc:date>2011-05-27T03:49:54Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0007334</oboInOwl:xref>
-        <rdfs:label>partial seizure evolving to secondarily generalized seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000669 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000669">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
-        <obo:IAO_0000115>&quot;An absence seizure is a brief (usually less that 20 seconds), generalized epileptic seizure of sudden onset and termination.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Absence_seizure]</obo:IAO_0000115>
-        <dc:date>2011-05-27T03:54:48Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>petit mal seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0002121</oboInOwl:xref>
-        <oboInOwl:xref>MP:0003216</oboInOwl:xref>
-        <rdfs:label>absence seizures</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000670 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000670">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
-        <obo:IAO_0000115>&quot;A type of generalized seizure that consist of a brief lapse in muscle tone that are caused by temporary alterations in brain function.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Atonic_seizure]</obo:IAO_0000115>
-        <dc:date>2011-05-27T03:57:35Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>akinetic seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>drop attack</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>drop seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0010819</oboInOwl:xref>
-        <rdfs:label>atonic seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000676 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000676">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
-        <obo:IAO_0000115>&quot;A type of generalized seizure characterised by a combination of tonic stiffening (extensions) followed by clonic flexion motions.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-27T05:03:11Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>gran mal seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>grand mal seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0002069</oboInOwl:xref>
-        <oboInOwl:xref>MP:0003997</oboInOwl:xref>
-        <rdfs:comment>The seizures are divided into two phases, the tonic phase and the clonic phase, hence the name of the seizure, though a tonic clonic seizure will often be preceded by an aura.</rdfs:comment>
-        <rdfs:label>tonic clonic seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000677 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000677">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000662"/>
-        <obo:IAO_0000115>&quot;A type of seizure characterised by muscle rigidity.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-27T05:09:15Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0010818</oboInOwl:xref>
-        <oboInOwl:xref>MP:0002826</oboInOwl:xref>
-        <rdfs:label>tonic seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000678 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000678">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
-        <obo:IAO_0000115>&quot;A type of seizure associated with a significant rise in body temperature.&quot; [wikpedia:http\://en.wikipedia.org/wiki/Febrile_seizure]</obo:IAO_0000115>
-        <dc:date>2011-05-27T05:13:26Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>febrile convulsion</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasExactSynonym>fever fit</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0002373</oboInOwl:xref>
-        <rdfs:label>febrile seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000686 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000686">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000012"/>
-        <obo:IAO_0000115>&quot;Paroxysmal events that mimic an epileptic seizure but do not involve abnormal, rhythmic discharges of cortical neurons.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Non-epileptic_seizure]</obo:IAO_0000115>
-        <dc:date>2011-05-27T05:47:13Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>non-epileptic seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <rdfs:label>provoked seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000690 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000690">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
-        <obo:IAO_0000115>&quot;Continuous unremitting seizure lasting longer than 30 minutes or recurrent seizures without regaining consciousness between seizures for greater than 30 minutes.&quot; [wikipedia:http\://en.wikipedia.org/wiki/Status_epilepticus]</obo:IAO_0000115>
-        <dc:date>2011-05-27T05:59:47Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0002133</oboInOwl:xref>
-        <rdfs:label>status epilepticus</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000702 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000702">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000669"/>
-        <obo:IAO_0000115>&quot;An absence seizure not induced by hyperventilation.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-28T11:59:31Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0007270</oboInOwl:xref>
-        <rdfs:label>atypical absence seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000712 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000712">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
-        <obo:IAO_0000115>&quot;A type of seizure induced by lower than normal level of blood glucose levels.&quot; [GVG:NBO]</obo:IAO_0000115>
-        <dc:date>2011-05-28T12:35:56Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0002173</oboInOwl:xref>
-        <rdfs:label>hypoglycemia induced seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000731 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000731">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000651"/>
-        <obo:IAO_0000115>&quot;A simple partial seizure affecting the kinesthetic behavior of one side of the body.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-28T05:51:10Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>unilateral clonic seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0006813</oboInOwl:xref>
-        <rdfs:label>hemiclonic seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000735 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000735">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
-        <obo:IAO_0000115>&quot;A type of seizure induced by lower than normal level of blood calcium levels.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-28T08:04:53Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0002199</oboInOwl:xref>
-        <rdfs:label>hypocalcemia induced seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000737 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000737">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000686"/>
-        <obo:IAO_0000115>&quot;A type of seizure induced by exposure to a light stimulus.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-28T08:34:10Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0001327</oboInOwl:xref>
-        <rdfs:label>photostimulation induced seizure</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000738 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000738">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
-        <obo:IAO_0000115>&quot;A type of epilepsy that is characterised a sudden burst of energy, usually in the form of laughing.&quot; [NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-28T11:12:42Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>gelastic seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0010821</oboInOwl:xref>
-        <rdfs:label>gelastic epilepsy</rdfs:label>
-    </owl:Class>
-    
-
-
-    <!-- http://purl.obolibrary.org/obo/NBO_0000739 -->
-
-    <owl:Class rdf:about="http://purl.obolibrary.org/obo/NBO_0000739">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/NBO_0000642"/>
-        <obo:IAO_0000115>&quot;A type of epilepsy that is characterised a sudden paroxysmal crying.&quot; [NBO:&lt;new dbxref&gt;, NBO:GVG]</obo:IAO_0000115>
-        <dc:date>2011-05-28T11:18:45Z</dc:date>
-        <oboInOwl:created_by>George Gkoutos</oboInOwl:created_by>
-        <oboInOwl:hasExactSynonym>dacrystic seizure</oboInOwl:hasExactSynonym>
-        <oboInOwl:hasOBONamespace>behavior_ontology</oboInOwl:hasOBONamespace>
-        <oboInOwl:xref>HP:0010820</oboInOwl:xref>
-        <rdfs:label>dacrystic epilepsy</rdfs:label>
     </owl:Class>
     
 


### PR DESCRIPTION
Fixes #7246

- removes all seizure classes from NBO permanently
- removes all EQ definitions referencing NBO seizure classes
