### PR TITLE
Add missing HPO top-level parent check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ src/ontology/behaviour_seed.txt
 site/*
 docs/cite.md
 docs/contributing.md
+src/ontology/reports/missing-parent-hpo-violation.csv

--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -41,7 +41,7 @@ REPORT_FAIL_ON =            ERROR
 REPORT_LABEL =              
 REPORT_PROFILE_OPTS =       
 OBO_FORMAT_OPTIONS =        
-SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference synonym_ends_with_illegal_character deprecated_class_reference iri-range label-with-iri taxon-range double-space illegal-synonym-type deprecated-consider illegal-annotation-property orcid-contributor orcid-xref-is-not-formatted-correctly xref-uses-unknown-prefix noparent nolabels 
+SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference synonym_ends_with_illegal_character deprecated_class_reference iri-range label-with-iri taxon-range double-space illegal-synonym-type deprecated-consider illegal-annotation-property orcid-contributor orcid-xref-is-not-formatted-correctly xref-uses-unknown-prefix noparent nolabels missing-parent-hpo 
 SPARQL_EXPORTS =            basic-report xrefs synonyms layperson-synonyms autoimmune-antibody-report hp-attribution-report 
 ODK_VERSION_MAKEFILE =      v1.4.3
 

--- a/src/ontology/hp-odk.yaml
+++ b/src/ontology/hp-odk.yaml
@@ -105,6 +105,7 @@ robot_report:
     - xref-uses-unknown-prefix
     - noparent
     - nolabels
+    - missing-parent-hpo
   custom_sparql_exports :
     - basic-report
     - xrefs

--- a/src/sparql/missing-parent-hpo-violation.sparql
+++ b/src/sparql/missing-parent-hpo-violation.sparql
@@ -10,6 +10,7 @@ SELECT DISTINCT ?entity ?property ?value WHERE {
     ?entity a owl:Class .
     FILTER NOT EXISTS { ?entity owl:deprecated true . }
     FILTER ( STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/HP_"))
+    FILTER (?entity != HP:0000001)
   }
   MINUS
   { 

--- a/src/sparql/missing-parent-hpo-violation.sparql
+++ b/src/sparql/missing-parent-hpo-violation.sparql
@@ -1,0 +1,25 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX HP: <http://purl.obolibrary.org/obo/HP_>
+
+# This test checks that all HP classes that are not deprecated
+# have a parent that is one of the top distinctions in HPO under "All"
+
+SELECT DISTINCT ?entity ?property ?value WHERE {
+  { 
+    ?entity a owl:Class .
+    FILTER NOT EXISTS { ?entity owl:deprecated true . }
+    FILTER ( STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/HP_"))
+  }
+  MINUS
+  { 
+     SELECT ?entity WHERE {
+       ?entity a owl:Class .
+       ?entity rdfs:subClassOf* ?parent .
+       VALUES ?parent { HP:0032223 HP:0012823 HP:0040279 HP:0000005 HP:0032443 HP:0000118 }
+    }
+  } .
+  ?entity rdfs:label ?label .
+  BIND(CONCAT(?label, " is not in a legal branch of HPO.") AS ?value)
+  BIND(rdfs:subClassOf AS ?property)
+}


### PR DESCRIPTION
@pnrobinson this test ensures that all non-deprecated HPO classes fall under one of the 6 top level classes in HPO. The output looks like this:

```
FAIL Rule ../sparql/missing-parent-hpo-violation.sparql: 3 violation(s)
entity,property,value
http://purl.obolibrary.org/obo/HP_0031412,http://www.w3.org/2000/01/rdf-schema#subClassOf,Abnormal telomere morphology is not in a legal branch of HPO.
http://purl.obolibrary.org/obo/HP_0031554,http://www.w3.org/2000/01/rdf-schema#subClassOf,Reduced granulocyte CD55 level is not in a legal branch of HPO.
http://purl.obolibrary.org/obo/HP_0031476,http://www.w3.org/2000/01/rdf-schema#subClassOf,Abnormal buccal mucosa cell morphology is not in a legal branch of HPO.
```

If it fails. 