### PR TITLE
Standardise all content in HPO to American English spelling

### DIFF
--- a/src/ontology/hp.Makefile
+++ b/src/ontology/hp.Makefile
@@ -222,6 +222,13 @@ tmp/british_synonyms.owl: $(SYN_TYPE_TEMPLATES) $(SRC)
 add_british_language_synonyms: $(SRC) tmp/british_synonyms.owl
 	$(ROBOT) merge -i hp-edit.owl -i tmp/british_synonyms.owl --collapse-import-closure false -o hp-edit.ofn && mv hp-edit.ofn hp-edit.owl
 
+# This updates all British English in Mondo to American English.
+.PHONY: americanize
+
+americanize: $(SRC) hpo_british_english_dictionary.csv
+	python ../scripts/americanize.py $^
+
+
 #########################################################################################################
 ### Process for merging a large template and remove existing content: ###################################
 #########################################################################################################

--- a/src/scripts/americanize.py
+++ b/src/scripts/americanize.py
@@ -32,7 +32,11 @@ def replace_words_from_dict(text, word_dict):
             result_lines.append(line)
         else:
             # This regex will capture words and preserve punctuations.
-            result_lines.append(re.sub(r"\b[\w\'-]+\b", replacement, line))
+            new_line = re.sub(r"\b[\w\'-]+\b", replacement, line)
+            # Special case for 'optic disk' -> 'optic disc'; this contradicts the dictionary.
+            new_line = new_line.replace('optic disk', 'optic disc')
+            new_line = new_line.replace('gasses', 'gases')
+            result_lines.append(new_line)
 
     return '\n'.join(result_lines)
 

--- a/src/scripts/americanize.py
+++ b/src/scripts/americanize.py
@@ -1,0 +1,43 @@
+import csv
+import re
+import sys
+
+replacements = {}
+
+input = sys.argv[1]
+dictionary = sys.argv[2]
+
+with open(dictionary, "r") as f:
+    reader = csv.reader(f)
+    next(reader)  # skip header
+    replacements = {rows[0]: rows[1] for rows in reader}
+
+with open(input, "r") as f:
+    text = f.read()
+
+
+def replace_words_from_dict(text, word_dict):
+    """Replace words in text based on dictionary, ignoring lines with 'uk-spelling'."""
+
+    def replacement(match):
+        word = match.group(0)
+        clean_word = word.strip('.,!?()[]{}":;')
+        return word.replace(clean_word, word_dict.get(clean_word, clean_word))
+
+    # Process the text line by line.
+    result_lines = []
+    for line in text.split('\n'):
+        if 'uk_spelling' in line:
+            # Skip replacement for this line.
+            result_lines.append(line)
+        else:
+            # This regex will capture words and preserve punctuations.
+            result_lines.append(re.sub(r"\b[\w\'-]+\b", replacement, line))
+
+    return '\n'.join(result_lines)
+
+
+content = replace_words_from_dict(text, replacements)
+
+with open(input, "w") as f:
+    f.write(content)


### PR DESCRIPTION
This PR 
- standardises all content in HPO to American English and adds a pipeline to do so programmatically. 
- refreshes the UK spelling synonyms
- standardises all uses of "optic disk" to "optic disc", in line with the recommendations of the "American Academy of ophthalmology"

@LCCarmody has reviewed the spellings and we corrected two issues about `gassing` and `optic disc`.