### PR TITLE
Add QC check to prevent labels and definitions with language tags

### DIFF
--- a/src/ontology/Makefile
+++ b/src/ontology/Makefile
@@ -10,7 +10,7 @@
 # More information: https://github.com/INCATools/ontology-development-kit/
 
 # Fingerprint of the configuration file when this Makefile was last generated
-CONFIG_HASH=                ab8c40cd1cac34eb21e9d0f95c87ff82020f04cc67b93398138596943da426a0
+CONFIG_HASH=                4a34191ec01b0d40547b09e5c942aeec3345fd881201f81bc0df620c997f468e
 
 
 # ----------------------------------------
@@ -44,7 +44,7 @@ REPORT_FAIL_ON =            ERROR
 REPORT_LABEL =              
 REPORT_PROFILE_OPTS =       
 OBO_FORMAT_OPTIONS =        
-SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference synonym_ends_with_illegal_character deprecated_class_reference iri-range label-with-iri taxon-range double-space illegal-synonym-type deprecated-consider illegal-annotation-property orcid-contributor orcid-xref-is-not-formatted-correctly xref-uses-unknown-prefix noparent nolabels missing-parent-hpo 
+SPARQL_VALIDATION_CHECKS =  equivalent-classes owldef-self-reference synonym_ends_with_illegal_character deprecated_class_reference iri-range label-with-iri taxon-range double-space illegal-synonym-type deprecated-consider illegal-annotation-property orcid-contributor orcid-xref-is-not-formatted-correctly xref-uses-unknown-prefix noparent nolabels missing-parent-hpo primary-label-translation-tag 
 SPARQL_EXPORTS =            basic-report xrefs synonyms layperson-synonyms autoimmune-antibody-report hp-attribution-report 
 ODK_VERSION_MAKEFILE =      v1.5
 

--- a/src/ontology/hp-odk.yaml
+++ b/src/ontology/hp-odk.yaml
@@ -172,6 +172,7 @@ robot_report:
     - noparent
     - nolabels
     - missing-parent-hpo
+    - primary-label-translation-tag
   custom_sparql_exports :
     - basic-report
     - xrefs

--- a/src/sparql/primary-label-translation-tag-violation.sparql
+++ b/src/sparql/primary-label-translation-tag-violation.sparql
@@ -1,0 +1,14 @@
+prefix IAO: <http://purl.obolibrary.org/obo/IAO_>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+
+# Test if an annotation has a language tag, which it shouldnt as per
+# https://github.com/obophenotype/human-phenotype-ontology/issues/10387#issuecomment-1999034724
+
+SELECT DISTINCT ?entity ?property ?value WHERE
+{
+  VALUES ?property { rdfs:label IAO:0000115 }
+  ?entity ?property ?value .
+ FILTER( !isBlank(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/HP_"))
+  FILTER(lang(?value) != "")
+} 

--- a/src/sparql/primary-label-translation-tag-violation.sparql
+++ b/src/sparql/primary-label-translation-tag-violation.sparql
@@ -7,7 +7,7 @@ prefix owl: <http://www.w3.org/2002/07/owl#>
 
 SELECT DISTINCT ?entity ?property ?value WHERE
 {
-  VALUES ?property { rdfs:label IAO:0000115 }
+  VALUES ?property { rdfs:label IAO:0000115 <http://www.geneontology.org/formats/oboInOwl#hasExactSynonym> }
   ?entity ?property ?value .
  FILTER( !isBlank(?entity) && STRSTARTS(str(?entity), "http://purl.obolibrary.org/obo/HP_"))
   FILTER(lang(?value) != "")


### PR DESCRIPTION
Fixes #10387 

This PR:

1. Removes `@en` language tags from
   - 990 labels
   - 2 definitions
   - 8 exact synonyms
2. Adds a QC check to ensures they will not come again