### PR TITLE
Reduce the chatter of the local QC pipeline

### DIFF
--- a/.github/workflows/qc.yml
+++ b/.github/workflows/qc.yml
@@ -19,7 +19,7 @@ jobs:
   ontology_qc:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: obolibrary/odkfull:v1.5
+    container: obolibrary/odkfull:v1.5.2
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/src/ontology/hp-qc-pipeline.sh
+++ b/src/ontology/hp-qc-pipeline.sh
@@ -39,8 +39,8 @@ java -jar $OWL_CHECK_JAR $HP_EDIT
 
 # The ODK QC and build:
 
-sh -e run.sh make IMP=false test #&> log.txt
-sh -e run.sh make IMP=false PAT=false MIR=false $HP_OBO
+sh -e run.sh make IMP=false PAT=false MIR=false test $HP_OBO -B #&> log.txt
+
 #- tail -n 100 log.txt
 # now check hp.obo for duplicated labels, synonyms that are used for different classes
 java -jar $OBO_CHECK_JAR $HP_OBO

--- a/src/ontology/hp.Makefile
+++ b/src/ontology/hp.Makefile
@@ -80,7 +80,7 @@ fastobo: hp.obo
 noequivalents:
 	$(ROBOT) reason --input $(SRC) remove --select imports reason --reasoner ELK --equivalent-classes-allowed asserted-only --output test.owl && rm test.owl && echo "Success"
 
-test: sparql_test all_reports test_obo hp_error consistency noequivalents fastobo
+test: sparql_test test_obo hp_error consistency noequivalents fastobo
 
 hp_labels.csv: $(SRC)
 	robot query --use-graphs true -f csv -i $(SRC) --query ../sparql/term_table.sparql $@


### PR DESCRIPTION
@pnrobinson asked me to ensure that the QC pipeline:

1. Never updates any files in git (previously, some reports were refreshed)
2. Is as fast as possible

This PR makes that change. Note, that for some reason, some (looking harmless) QC errors are being noted by the pipeline, such as:

```
Redundant subclass assertion found: 
   - Focal impaired awareness behavior arrest seizure (HP:0032790) -> Dialeptic seizure (HP:0011146)

Redundant subclass assertion found: 
   - Abnormal renal glomerulus morphology (HP:0000095) -> Abnormal nephron morphology (HP:0012575)
```

But I guess you will fix these when you next curate. (This part of the QC is not run on GitHub, only in your local CI)